### PR TITLE
fix: discord link

### DIFF
--- a/pages/_meta.json
+++ b/pages/_meta.json
@@ -15,7 +15,7 @@
   "contact": {
     "title": "Join Us",
     "type": "page",
-    "href": "https://discord.gg/qxrr6KJj",
+    "href": "https://discord.gg/GVvKdk8rdW",
     "newWindow": true
   }
 }


### PR DESCRIPTION
# This PR fixes the Discord invite link by:

- Setting a limit of 100 invitations
- Adding unlimited duration